### PR TITLE
some minor updates

### DIFF
--- a/lib/carrierwave/crop/helpers.rb
+++ b/lib/carrierwave/crop/helpers.rb
@@ -57,7 +57,7 @@ module CarrierWave
           model_name = self.object.class.name.downcase.split("::").last
           hidden_elements  = ActiveSupport::SafeBuffer.new
           [:crop_x, :crop_y, :crop_w, :crop_h].each do |attribute|
-            hidden_elements << self.hidden_field(:"#{attachment}_#{attribute}", id: "#{model_name}_#{attachment}_cropbox_#{attribute}")
+            hidden_elements << self.hidden_field(:"#{attachment}_#{attribute}", id: "#{model_name}_#{attachment}_#{attribute}")
           end
 
           box =  @template.content_tag(:div, hidden_elements, style: "display:none")

--- a/lib/carrierwave/crop/helpers.rb
+++ b/lib/carrierwave/crop/helpers.rb
@@ -54,10 +54,10 @@ module CarrierWave
 
         if(attachment_instance.class.ancestors.include? CarrierWave::Uploader::Base )
           ## Fixes Issue #1 : Colons in html id attributes with Namespaced Models
-          model_name = self.object.class.name.downcase.split("::").last 
-          hidden_elements  = self.hidden_field(:"#{attachment}_crop_x", id: "#{model_name}_#{attachment}_crop_x")
-          [:crop_y, :crop_w, :crop_h].each do |attribute|
-            hidden_elements << self.hidden_field(:"#{attachment}_#{attribute}", id: "#{model_name}_#{attachment}_#{attribute}")
+          model_name = self.object.class.name.downcase.split("::").last
+          hidden_elements  = ActiveSupport::SafeBuffer.new
+          [:crop_x, :crop_y, :crop_w, :crop_h].each do |attribute|
+            hidden_elements << self.hidden_field(:"#{attachment}_#{attribute}", id: "#{model_name}_#{attachment}_cropbox_#{attribute}")
           end
 
           box =  @template.content_tag(:div, hidden_elements, style: "display:none")

--- a/lib/carrierwave/crop/model_additions.rb
+++ b/lib/carrierwave/crop/model_additions.rb
@@ -15,7 +15,7 @@ module CarrierWave
           [:crop_x, :crop_y, :crop_w, :crop_h].each do |a|
             attr_accessor :"#{attachment}_#{a}"
           end
-          after_update :"recreate_#{attachment}_versions"
+          after_save :"recreate_#{attachment}_versions"
 
         end
 

--- a/lib/generators/templates/carrierwave_cropper.js.coffee
+++ b/lib/generators/templates/carrierwave_cropper.js.coffee
@@ -10,10 +10,10 @@ class CarrierWaveCropper
       onChange: @update
 
   update: (coords) =>
-    $('#<%= file_name %>_<%= attachment_name %>_crop_x').val(coords.x)
-    $('#<%= file_name %>_<%= attachment_name %>_crop_y').val(coords.y)
-    $('#<%= file_name %>_<%= attachment_name %>_crop_w').val(coords.w)
-    $('#<%= file_name %>_<%= attachment_name %>_crop_h').val(coords.h)
+    $('#<%= file_name %>_<%= attachment_name %>_cropbox_crop_x').val(coords.x)
+    $('#<%= file_name %>_<%= attachment_name %>_cropbox_crop_y').val(coords.y)
+    $('#<%= file_name %>_<%= attachment_name %>_cropbox_crop_w').val(coords.w)
+    $('#<%= file_name %>_<%= attachment_name %>_cropbox_crop_h').val(coords.h)
     @updatePreview(coords)
 
   updatePreview: (coords) =>

--- a/lib/generators/templates/carrierwave_cropper.js.coffee
+++ b/lib/generators/templates/carrierwave_cropper.js.coffee
@@ -10,10 +10,10 @@ class CarrierWaveCropper
       onChange: @update
 
   update: (coords) =>
-    $('#<%= file_name %>_<%= attachment_name %>_cropbox_crop_x').val(coords.x)
-    $('#<%= file_name %>_<%= attachment_name %>_cropbox_crop_y').val(coords.y)
-    $('#<%= file_name %>_<%= attachment_name %>_cropbox_crop_w').val(coords.w)
-    $('#<%= file_name %>_<%= attachment_name %>_cropbox_crop_h').val(coords.h)
+    $('#<%= file_name %>_<%= attachment_name %>_crop_x').val(coords.x)
+    $('#<%= file_name %>_<%= attachment_name %>_crop_y').val(coords.y)
+    $('#<%= file_name %>_<%= attachment_name %>_crop_w').val(coords.w)
+    $('#<%= file_name %>_<%= attachment_name %>_crop_h').val(coords.h)
     @updatePreview(coords)
 
   updatePreview: (coords) =>


### PR DESCRIPTION
- In my project I use this gem to crop images even before being uploaded. So I've changed `before_update` to `before_save` which makes it more generic. Now it works before upload and update after upload.
- For naming consistency hidden_fields should contain crop_box. I've also replaced string with `ActiveSupport::SafeBuffer` to loop through the crop fields.
