### PR TITLE
Allow version-based `id` attribute

### DIFF
--- a/lib/carrierwave/crop/helpers.rb
+++ b/lib/carrierwave/crop/helpers.rb
@@ -13,6 +13,7 @@ module CarrierWave
       #   previewbox :avatar
       #   previewbox :avatar, width: 200, height: 200
       #   previewbox :avatar, version: :medium
+      #   previewbox :avatar, version: :medium, as: :standard_version
       #
       # @param attachment [Symbol] attachment name
       # @param opts [Hash] specify version or width and height options
@@ -21,18 +22,19 @@ module CarrierWave
 
         if(self.object.send(attachment).class.ancestors.include? CarrierWave::Uploader::Base )
           ## Fixes Issue #1 : Colons in html id attributes with Namespaced Models
-          model_name = self.object.class.name.downcase.split("::").last 
+          model_name = self.object.class.name.downcase.split("::").last
           width, height = 100, 100
           if(opts[:width] && opts[:height])
             width, height = opts[:width].round, opts[:height].round
           end
-          wrapper_attributes = {id: "#{model_name}_#{attachment}_previewbox_wrapper", style: "width:#{width}px; height:#{height}px; overflow:hidden"}
+          preview_as = opts[:as].present? ? "_#{opts[:as]}" : ""
+          wrapper_attributes = {id: "#{model_name}_#{attachment}#{preview_as}_previewbox_wrapper", style: "width:#{width}px; height:#{height}px; overflow:hidden"}
           if opts[:version]
             img = self.object.send(attachment).url(opts[:version])
           else
             img = self.object.send(attachment).url
           end
-          preview_image = @template.image_tag(img, id: "#{model_name}_#{attachment}_previewbox")
+          preview_image = @template.image_tag(img, id: "#{model_name}_#{attachment}#{preview_as}_previewbox")
           @template.content_tag(:div, preview_image, wrapper_attributes)
         end
       end
@@ -54,7 +56,7 @@ module CarrierWave
 
         if(attachment_instance.class.ancestors.include? CarrierWave::Uploader::Base )
           ## Fixes Issue #1 : Colons in html id attributes with Namespaced Models
-          model_name = self.object.class.name.downcase.split("::").last 
+          model_name = self.object.class.name.downcase.split("::").last
           hidden_elements  = self.hidden_field(:"#{attachment}_crop_x", id: "#{model_name}_#{attachment}_crop_x")
           [:crop_y, :crop_w, :crop_h].each do |attribute|
             hidden_elements << self.hidden_field(:"#{attachment}_#{attribute}", id: "#{model_name}_#{attachment}_#{attribute}")


### PR DESCRIPTION
This will allow for more customizable preview boxes for different versions of the photo you are cropping (e.g. `retina` (500x500), `standard` (250x250))

Let me know how this looks and I will update the `README`.
