### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Render a view after creating/updating a user, add a `crop` action in your `contr
       end
     end
 
-For `Rails 4.x`, whitelist the cropping attributes - `fieldname_crop_x`, `fieldname_crop_y`, `fieldname_crop_w`, `fieldname_crop_h`.
+For `Rails 4.x`, whitelist the cropping attributes - `fieldname_crop_x`, `fieldname_crop_y`, `fieldname_crop_w`, `fieldname_crop_h` before `fieldname`.
 
 For example:
 


### PR DESCRIPTION
The order of whitelisted fields seems to reflect the order in which attributes are assigned to the model. The cropper assumes the `_crop_X` fields are assigned before the file is given to the uploader.
