### PR TITLE
Add "only version(s)" and data html attributes for javascript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ test/tmp
 test/version_tmp
 tmp
 .DS_Store
+*.swp
+*.swo

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ CarrierWave extension to crop uploaded images using Jcrop plugin with preview.
           process crop: :image
         end
 
-        #Set crop versions for example in _ipad.html.erb partial
+        #Set crop versions for example in _andtoid.html.erb partial
         <%= f.cropbox :avatar, only: :android_main %>
 
 
@@ -215,7 +215,7 @@ If there are no versions, and original file is to be cropped directly then call 
           process crop: :image
         end
 
-        #Set crop versions for example in _ipad.html.erb partial
+        #Set crop versions for example in _android.html.erb partial
         <%= f.cropbox :avatar, only: :android_main %>
 
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,38 @@
 
 CarrierWave extension to crop uploaded images using Jcrop plugin with preview.
 
+
+## This is a fork of gem.
+### Two changes from main version(PR is sent)
+
+8. You can set versions where need to crop.
+
+        #Version for ipad
+        version :ipad_main do
+          process crop: :image
+        end
+
+        #Set crop versions for example in _ipad.html.erb partial
+        <%= f.cropbox :avatar, only: :ipad_main %>
+
+        #Version for android
+        version :android_main do
+          process crop: :image
+        end
+
+        #Set crop versions for example in _ipad.html.erb partial
+        <%= f.cropbox :avatar, only: :android_main %>
+
+
+        #or both
+        <%= f.cropbox :avatar, only: [:ipad_main, :android_main] %>
+
+9. If you need to html data attributes you can set data option
+
+        <%= f.cropbox :avatar, data: {width: 1024, height: 768} %>
+
+        #and you can use it in javascript
+
 ## Installation
 
 Install the latest stable release:
@@ -167,6 +199,35 @@ If there are no versions, and original file is to be cropped directly then call 
           process crop: [:avatar, 600, 600]
           resize_to_limit(100,100)
         end
+
+8. You can set versions where need to crop.
+
+        #Version for ipad
+        version :ipad_main do
+          process crop: :image
+        end
+
+        #Set crop versions for example in _ipad.html.erb partial
+        <%= f.cropbox :avatar, only: :ipad_main %>
+
+        #Version for android
+        version :android_main do
+          process crop: :image
+        end
+
+        #Set crop versions for example in _ipad.html.erb partial
+        <%= f.cropbox :avatar, only: :android_main %>
+
+
+        #or both
+        <%= f.cropbox :avatar, only: [:ipad_main, :android_main] %>
+
+9. If you need to html data attributes you can set data option
+
+        <%= f.cropbox :avatar, data: {width: 1024, height: 768} %>
+
+        #and you can use it in javascript
+
 
 ### Credits and resources
 * [CarrierWave](https://github.com/carrierwaveuploader/carrierwave)

--- a/lib/carrierwave/crop/model_additions.rb
+++ b/lib/carrierwave/crop/model_additions.rb
@@ -52,7 +52,12 @@ module CarrierWave
 
             attachment_instance = send(attachment)
             if only_version
-              attachment_instance.recreate_versions!(only_version)
+              if only_version.is_a? Array
+                only_version.map!(&:to_sym)
+                attachment_instance.recreate_versions!(*only_version)
+              else
+                attachment_instance.recreate_versions!(only_version.to_sym)
+              end
             else
               attachment_instance.recreate_versions!
             end

--- a/lib/carrierwave/crop/model_additions.rb
+++ b/lib/carrierwave/crop/model_additions.rb
@@ -48,16 +48,13 @@ module CarrierWave
         def crop_image(attachment)
           if cropping?(attachment)
             only_version = self.send("#{attachment}_only_version")
-            only_version = only_version.to_sym if only_version.is_a? String
+            only_version = [only_version] if only_version.is_a? String
 
             attachment_instance = send(attachment)
-            if only_version
-              if only_version.is_a? Array
-                only_version.map!(&:to_sym)
-                attachment_instance.recreate_versions!(*only_version)
-              else
-                attachment_instance.recreate_versions!(only_version.to_sym)
-              end
+
+            if only_version.is_a? Array
+              only_version.map!(&:to_sym)
+              attachment_instance.recreate_versions!(*only_version)
             else
               attachment_instance.recreate_versions!
             end

--- a/lib/carrierwave/crop/model_additions.rb
+++ b/lib/carrierwave/crop/model_additions.rb
@@ -12,7 +12,7 @@ module CarrierWave
         # @param attachment [Symbol] Name of the attachment attribute to be cropped
         def crop_uploaded(attachment)
 
-          [:crop_x, :crop_y, :crop_w, :crop_h].each do |a|
+          [:crop_x, :crop_y, :crop_w, :crop_h, :only_version].each do |a|
             attr_accessor :"#{attachment}_#{a}"
           end
           after_update :"recreate_#{attachment}_versions"
@@ -47,8 +47,15 @@ module CarrierWave
         # @param  attachment [Symbol] Name of the attribute to be cropped
         def crop_image(attachment)
           if cropping?(attachment)
+            only_version = self.send("#{attachment}_only_version")
+            only_version = only_version.to_sym if only_version.is_a? String
+
             attachment_instance = send(attachment)
-            attachment_instance.recreate_versions!
+            if only_version
+              attachment_instance.recreate_versions!(only_version)
+            else
+              attachment_instance.recreate_versions!
+            end
           end
         end
 
@@ -59,12 +66,12 @@ module CarrierWave
     module Uploader
 
       # Performs cropping.
-      #  
-      #  On original version of attachment
-      #  process crop: :avatar  
       #
-      #  Resizes the original image to 600x600 and then performs cropping 
-      #  process crop: [:avatar, 600, 600]  
+      #  On original version of attachment
+      #  process crop: :avatar
+      #
+      #  Resizes the original image to 600x600 and then performs cropping
+      #  process crop: [:avatar, 600, 600]
       #
       # @param attachment [Symbol] Name of the attachment attribute to be cropped
       def crop(attachment, width = nil, height = nil)
@@ -73,21 +80,21 @@ module CarrierWave
           y = model.send("#{attachment}_crop_y").to_i
           w = model.send("#{attachment}_crop_w").to_i
           h = model.send("#{attachment}_crop_h").to_i
+          only_version = model.send("#{attachment}_only_version")
           attachment_instance = model.send(attachment)
 
           if self.respond_to? "resize_to_limit"
-
             begin
-              if width && height
-                resize_to_limit(width, height)
-              end
-              manipulate! do |img|
-                if attachment_instance.kind_of? CarrierWave::RMagick
-                  img.crop!(x, y, w, h)
-                elsif attachment_instance.kind_of? CarrierWave::MiniMagick
-                  img.crop("#{w}x#{h}+#{x}+#{y}")
-                  img
+              if only_version
+                if only_version.is_a? Array
+                  only_version.each do |item|
+                    crop_manipulate(attachment_instance, width, height, x, y, w, h) if item.to_sym == self.version_name.to_sym
+                  end
+                else
+                  crop_manipulate(attachment_instance, width, height, x, y, w, h) if only_version.to_sym == self.version_name.to_sym
                 end
+              elsif only_version.nil?
+                crop_manipulate(attachment_instance, width, height, x, y, w, h)
               end
 
             rescue Exception => e
@@ -96,6 +103,21 @@ module CarrierWave
 
           else
             raise CarrierWave::Crop::MissingProcessorError, "Failed to crop #{attachment}. Add rmagick or mini_magick."
+          end
+        end
+      end
+
+      #manipulate croping
+      def crop_manipulate(attachment_instance, width, height, x, y, w, h)
+        if width && height
+          resize_to_limit(width, height)
+        end
+        manipulate! do |img|
+          if attachment_instance.kind_of? CarrierWave::RMagick
+            img.crop!(x, y, w, h)
+          elsif attachment_instance.kind_of? CarrierWave::MiniMagick
+            img.crop("#{w}x#{h}+#{x}+#{y}")
+            img
           end
         end
       end


### PR DESCRIPTION
You can set versions where need to crop.

```
    #Version for ipad
    version :ipad_main do
      process crop: :image
    end

    #Set crop versions for example in _ipad.html.erb partial
    <%= f.cropbox :avatar, only: :ipad_main %>

    #Version for android
    version :android_main do
      process crop: :image
    end

    #Set crop versions for example in _andtoid.html.erb partial
    <%= f.cropbox :avatar, only: :android_main %>


    #or both
    <%= f.cropbox :avatar, only: [:ipad_main, :android_main] %>
```

 If you need to html data attributes you can set data option

```
    <%= f.cropbox :avatar, data: {width: 1024, height: 768} %>

    #and you can use it in javascript
```
